### PR TITLE
Cargo.toml: default-run to lorikeet.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 exclude = [
   "tests/*"
 ]
+default-run = "lorikeet"
 
 
 [features]


### PR DESCRIPTION
So

```
cargo run
```
works